### PR TITLE
fixes a bug where new named entry is created

### DIFF
--- a/R/clean_coordinates.R
+++ b/R/clean_coordinates.R
@@ -321,6 +321,7 @@ clean_coordinates <- function(x,
       value = "ids", verbose = verbose
     )
     otl <- rep(TRUE, nrow(x))
+    names(otl) <- seq_len(nrow(x))
     otl[otl_flag] <- FALSE
     out$otl <- otl
   }


### PR DESCRIPTION
I ran into an issue when trying CoordinateCleaner's `clean_coordinates()` — I was getting an error that I was adding a column to a dataframe and the lengths didn't match up. The issue is that the flagged entries are assigned through names, but names were not set on the vector. This fixes it on my end, and I figured might be useful. 