### PR TITLE
Correction to docs

### DIFF
--- a/R/clean_coordinates.R
+++ b/R/clean_coordinates.R
@@ -54,8 +54,8 @@
 #' @aliases CleanCoordinates summary.spatialvalid is.spatialvalid
 #' 
 #' @param species a character string. A vector of the same length as rows in x,
-#' with the species identity for each record.  If missing, the outliers test is
-#' skipped.
+#' with the species identity for each record.  If NULL, \code{tests} must not
+#' include the "outliers" or "duplicates" tests.
 #' @param countries a character string. The column with the country assignment of
 #' each record in three letter ISO code. Default = \dQuote{countrycode}. If missing, the
 #' countries test is skipped.

--- a/man/clean_coordinates.Rd
+++ b/man/clean_coordinates.Rd
@@ -50,8 +50,8 @@ Default = \dQuote{decimallongitude}.}
 Default = \dQuote{decimallatitude}.}
 
 \item{species}{a character string. A vector of the same length as rows in x,
-with the species identity for each record.  If missing, the outliers test is
-skipped.}
+with the species identity for each record.  If NULL, \code{tests} must not
+include the "outliers" or "duplicates" tests.}
 
 \item{countries}{a character string. The column with the country assignment of
 each record in three letter ISO code. Default = \dQuote{countrycode}. If missing, the


### PR DESCRIPTION
`species` arg has a default so can't be missing. Should refer to if arg is NULL, as per https://github.com/ropensci/CoordinateCleaner/blob/00058929bd41d33637157befd5aa85438c3cde37/R/clean_coordinates.R#L222-L229